### PR TITLE
[FIX] JSX.IntrinsicElement Error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,6 @@
-import { useState } from 'react'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
     <h1>Rutabaga</h1>
   )


### PR DESCRIPTION
GitHub Issue: #6 

### What?
I updated my IDE settings to use my workspace's version of typescript instead of the built in version of typescript.

### Why?
To resolve the following error when using html style tags in JSX return statements.

`Property 'h1' does not exist on type 'JSX.IntrinsicElements'.ts(2339)`

### How?
I used the VSCode command pallette to run the `TypeScript: Select TypeScript version` command and selected Use Workspace version

closes #6 

