### PR TITLE
[Feature] Content Row

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -1,6 +1,11 @@
 /* Styling for the Card component */
 
 /* 
+    Formatted with Stylelint https://stylelint.io/user-guide/get-started
+    Reference '.stylelintrc.json' for rules 
+*/
+
+/* 
     Blocks    [block] 
     Elements  [block]__[element] 
     Modifiers [block]--[modifier]
@@ -11,8 +16,7 @@
 .card {
     height: 438px;
     width: 100%;
-    margin-top: 48px;
-    margin-bottom: 48px;
+    margin-bottom: 24px;
     text-align: center;
     font-family: sans-serif, Arial, Helvetica;
     border-radius: 5%;

--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -7,16 +7,6 @@
 
     https://en.bem.info/methodology/quick-start/
 */
-
-.card-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    justify-items: center;
-    column-gap: 24px;
-    row-gap: 24px;
-    max-width: 948px;
-    margin: 0 auto;
-  }
   
 .card {
     height: 438px;

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -2,14 +2,14 @@
 
 import './Card.css'
 
-export type CardProps = {
-    titles: string[];
-    images: string[];
-    imageAlts: string[];
-    descriptions: string[];
+type CardProps = {
+    title: string;
+    image: string;
+    imageAlt: string;
+    description: string;
 };
 
-function display(title: string, image: string, imageAlt: string, description: string) {
+export const Card: React.FC<CardProps> = ({ title, image, imageAlt, description }) => {
     return (
         <div className="card">
             <div className="card__title">
@@ -24,16 +24,6 @@ function display(title: string, image: string, imageAlt: string, description: st
             <div className="card__description">
                 {description}
             </div>
-        </div>
-    );
-}
-
-export const Card: React.FC<CardProps> = ({ titles, images, imageAlts, descriptions }) => {
-    return (
-        <div className="card-container">
-            {Array.from({ length: titles.length }, (_, index) => (
-                <div key={index}>{display(titles[index], images[index], imageAlts[index], descriptions[index])}</div>
-            ))}
         </div>
     );
 }

--- a/src/components/ContentRow/ContentRow.css
+++ b/src/components/ContentRow/ContentRow.css
@@ -13,6 +13,16 @@
     https://en.bem.info/methodology/quick-start/
 */
 
+.content-row-line {
+    width: 948px;
+    margin: 0 auto;
+    margin-bottom: 24px;
+    display: block;
+    height: 1px;
+    border: 0;
+    border-top: 1px solid silver;
+}
+
 .content-row {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/src/components/ContentRow/ContentRow.css
+++ b/src/components/ContentRow/ContentRow.css
@@ -1,0 +1,24 @@
+/* Styling for the Card component */
+
+/* 
+    Formatted with Stylelint https://stylelint.io/user-guide/get-started
+    Reference '.stylelintrc.json' for rules 
+*/
+
+/* 
+    Blocks    [block] 
+    Elements  [block]__[element] 
+    Modifiers [block]--[modifier]
+
+    https://en.bem.info/methodology/quick-start/
+*/
+
+.content-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    justify-items: center;
+    column-gap: 24px;
+    row-gap: 24px;
+    max-width: 948px;
+    margin: 0 auto;
+}

--- a/src/components/ContentRow/ContentRow.tsx
+++ b/src/components/ContentRow/ContentRow.tsx
@@ -12,16 +12,21 @@ export type ContentRowProps = {
 
 export const ContentRow: React.FC<ContentRowProps> = ({ titles, images, imageAlts, descriptions }) => {
     return (
-        <div className="content-row">
-            {Array.from({ length: titles.length }, (_, index) => (
-                <Card
-                    title={titles[index]}
-                    image={images[index]}
-                    imageAlt={imageAlts[index]}
-                    description={descriptions[index]}>
-                </Card>
-            ))}
-        </div>
+        <>
+            <hr className="content-row-line"></hr>
+            <div className="content-row">
+                {Array.from({ length: titles.length }, (_, index) => (
+                    <Card
+                        title={titles[index]}
+                        image={images[index]}
+                        imageAlt={imageAlts[index]}
+                        description={descriptions[index]}>
+                    </Card>
+                ))}
+            </div>
+            <hr className="content-row-line"></hr>
+        </>
+       
     );
 }
 

--- a/src/components/ContentRow/ContentRow.tsx
+++ b/src/components/ContentRow/ContentRow.tsx
@@ -1,0 +1,28 @@
+// Displays a group of cards in a grid pattern 
+
+import Card from '../Card/Card.tsx';
+import './ContentRow.css'
+
+export type ContentRowProps = {
+    titles: string[];
+    images: string[];
+    imageAlts: string[];
+    descriptions: string[];
+};
+
+export const ContentRow: React.FC<ContentRowProps> = ({ titles, images, imageAlts, descriptions }) => {
+    return (
+        <div className="content-row">
+            {Array.from({ length: titles.length }, (_, index) => (
+                <Card
+                    title={titles[index]}
+                    image={images[index]}
+                    imageAlt={imageAlts[index]}
+                    description={descriptions[index]}>
+                </Card>
+            ))}
+        </div>
+    );
+}
+
+export default ContentRow;

--- a/src/components/Intro/Intro.css
+++ b/src/components/Intro/Intro.css
@@ -1,6 +1,11 @@
 /* Styling for the Intro component */
 
 /* 
+    Formatted with Stylelint https://stylelint.io/user-guide/get-started
+    Reference '.stylelintrc.json' for rules 
+*/
+
+/* 
     Blocks    [block] 
     Elements  [block]__[element] 
     Modifiers [block]--[modifier]
@@ -21,5 +26,6 @@
     font-size: 20px;
     margin-left: 20%;
     margin-right: 20%;
+    margin-bottom: 24px;
     color: #546E7A;
 }

--- a/src/components/Section/Section.css
+++ b/src/components/Section/Section.css
@@ -1,6 +1,11 @@
 /* Styling for the Section component */
 
 /* 
+    Formatted with Stylelint https://stylelint.io/user-guide/get-started
+    Reference '.stylelintrc.json' for rules 
+*/
+
+/* 
     Blocks    [block] 
     Elements  [block]__[element] 
     Modifiers [block]--[modifier]

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -37,7 +37,7 @@ const Home = () => {
           subtitle={introContent.subtitle}>
         </Intro>
       </Section>
-      <Section className="content-row-background">
+      <Section>
         <ContentRow
           titles={contentRowValues.titles}
           images={contentRowValues.images}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,14 +2,14 @@
 
 import Section from "../components/Section/Section.tsx"
 import { Intro, IntroProps } from "../components/Intro/Intro.tsx"
-import { Card, CardProps } from "../components/Card/Card.tsx"
+import { ContentRow, ContentRowProps } from "../components/ContentRow/ContentRow.tsx";
 
 const introContent: IntroProps = {
   title: "Rutabaga Reading",
   subtitle: "Keep all the metrics about your favorite books, all in one place. Rutabaga running is a platform where you can keep tallies on the books you've read and what you love about them."
 }
 
-const contentRowValues: CardProps = {
+const contentRowValues: ContentRowProps = {
   titles: ["Log A Book", 
            "Add to Your Wishlist", 
            "View & Manage Goals"
@@ -38,12 +38,12 @@ const Home = () => {
         </Intro>
       </Section>
       <Section className="content-row-background">
-        <Card 
+        <ContentRow
           titles={contentRowValues.titles}
           images={contentRowValues.images}
           imageAlts={contentRowValues.imageAlts}
           descriptions={contentRowValues.descriptions}>
-        </Card>
+        </ContentRow>
       </Section>
     </>
   )


### PR DESCRIPTION
GitHub Issue: #19 

### What?

- Created a new component called 'ContentRow' to containerize any number of card components and render them in a grid-like fashion. 
- Extracted the grid styling logic from the Card component
- Added a visual divider line on the top and bottom of the content row
- Refactored previous margin values for the Intro & Card components

### Why?
Creating this component is necessary because it removes logic for anything other than rendering a single card component from the card component.

Previously, the Card component was rendering a group of different cards at once and styling them into a grid. now, only a single card is rendered with this component and the new Content row component handles organizing multiple cards into a grid display. 

Both of these components working together creates code reusability and follows the principle that a component should do one job and one job only.

### How?
To extract the logic to render several card components in a grid, I grabbed the Array.from loop from the Card component and placed it in a new component called ContentRow.

To make that work, I had to adjust the ContentRowProps & CardProps to accept either strings or arrays of strings.

I also had to grab the contents of the display function and place it in the Card component. That's what was originally displaying a single card at a time so reusing it was easy.

### Notes
Not sure if I want to keep both lines that are displayed on the new content row component or not, for now I'm leaving it in. If it doesn't look good with other content below it in the future, I'll remove it.

closes #19

