### PR TITLE
[Fix] Remove Vite Title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,11 @@
     <meta charset="UTF-8" />
     <link
       rel="icon"
-      type="image/svg+xml"
-      href="/vite.svg" />
+      href="https://www.vecteezy.com/free-vector/rutabaga" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Rutabaga</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
GitHub Issue: #27 

### What?

The following Vite generated parameters were removed from the root index.html:

- Title
- Icon

### Why?

The title & icon that were generated by Vite are no longer relevant to the project

### How?

I changed the <title> value to 'Rutabaga' and I referenced [this royalty free icon](https://www.vecteezy.com/free-vector/rutabaga)

closes #27
